### PR TITLE
Fixed defines.c not being seen due to wrong script path

### DIFF
--- a/GameLabsDefine/config.cpp
+++ b/GameLabsDefine/config.cpp
@@ -23,14 +23,14 @@ class CfgMods
             {
                 value = "";
                 files[] = {
-                    "GameLabsDefine/Global"
+                    "GameLabs/GameLabsDefine/Global"
                 };
             };
             class gameScriptModule
             {
                 value = "";
                 files[]={
-                    "GameLabsDefine/Global"
+                    "GameLabs/GameLabsDefine/Global"
                 };
             };
 
@@ -38,7 +38,7 @@ class CfgMods
             {
                 value="";
                 files[]={
-                    "GameLabsDefine/Global"
+                    "GameLabs/GameLabsDefine/Global"
                 };
             };
 
@@ -46,7 +46,7 @@ class CfgMods
             {
                 value="";
                 files[]={
-                    "GameLabsDefine/Global"
+                    "GameLabs/GameLabsDefine/Global"
                 };
             };
         };


### PR DESCRIPTION
Script path was GameLabsDefine/Global, but prefix is GameLabs/GameLabsDefine, so defines.c is not seen by the game